### PR TITLE
Instance for `Text` and `Void`

### DIFF
--- a/.github/workflows/haskell.yaml
+++ b/.github/workflows/haskell.yaml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        resolver: [lts-14, lts-16, lts-18, lts-19, lts-20, lts-21, lts-22, nightly]
+        resolver: [lts-14, lts-16, lts-18, lts-19, lts-20, lts-21, lts-22, lts-23, nightly]
         include:
           - resolver: lts-14
             ghc: 8.6.5
@@ -45,6 +45,9 @@ jobs:
             stack-yaml: stack-coveralls.yaml
           - resolver: lts-22
             ghc: 9.6.6
+          - resolver: lts-23
+            ghc: 9.8.4
+            stack-yaml: stack.yaml
           - resolver: nightly
             ghc: 9.8.2
             stack-yaml: stack.yaml
@@ -125,27 +128,30 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { cabal: "3.12", os: ubuntu-latest, ghc: "8.6.5" }
-          - { cabal: "3.12", os: ubuntu-latest, ghc: "8.8.4" }
-          - { cabal: "3.12", os: ubuntu-latest, ghc: "8.10.7" }
-          - { cabal: "3.12", os: ubuntu-latest, ghc: "9.0.2" }
-          - { cabal: "3.12", os: ubuntu-latest, ghc: "9.2.8" }
-          - { cabal: "3.12", os: ubuntu-latest, ghc: "9.4.8" }
-          - { cabal: "3.12", os: ubuntu-latest, ghc: "9.6.6" }
-          - { cabal: "3.12", os: ubuntu-latest, ghc: "9.8.2" }
-          - { cabal: "3.12", os: ubuntu-latest, ghc: "9.10.1" }
-          - { cabal: "3.12", os: windows-latest, ghc: "9.0.2" }
-          - { cabal: "3.12", os: windows-latest, ghc: "9.2.8" }
-          - { cabal: "3.12", os: windows-latest, ghc: "9.4.8" }
-          - { cabal: "3.12", os: windows-latest, ghc: "9.6.6" }
-          - { cabal: "3.12", os: windows-latest, ghc: "9.8.2" }
-          - { cabal: "3.12", os: windows-latest, ghc: "9.10.1" }
-          - { cabal: "3.12", os: macOS-13, ghc: "9.0.2" }
-          - { cabal: "3.12", os: macOS-latest, ghc: "9.2.8" }
-          - { cabal: "3.12", os: macOS-latest, ghc: "9.4.8" }
-          - { cabal: "3.12", os: macOS-latest, ghc: "9.6.6" }
-          - { cabal: "3.12", os: macOS-latest, ghc: "9.8.2" }
-          - { cabal: "3.12", os: macOS-latest, ghc: "9.10.1" }
+          - { cabal: "3.14", os: ubuntu-latest, ghc: "8.6.5" }
+          - { cabal: "3.14", os: ubuntu-latest, ghc: "8.8.4" }
+          - { cabal: "3.14", os: ubuntu-latest, ghc: "8.10.7" }
+          - { cabal: "3.14", os: ubuntu-latest, ghc: "9.0.2" }
+          - { cabal: "3.14", os: ubuntu-latest, ghc: "9.2.8" }
+          - { cabal: "3.14", os: ubuntu-latest, ghc: "9.4.8" }
+          - { cabal: "3.14", os: ubuntu-latest, ghc: "9.6.6" }
+          - { cabal: "3.14", os: ubuntu-latest, ghc: "9.8.4" }
+          - { cabal: "3.14", os: ubuntu-latest, ghc: "9.10.1" }
+          # - { cabal: "3.14", os: ubuntu-latest, ghc: "9.12.1" }
+          - { cabal: "3.14", os: windows-latest, ghc: "9.0.2" }
+          - { cabal: "3.14", os: windows-latest, ghc: "9.2.8" }
+          - { cabal: "3.14", os: windows-latest, ghc: "9.4.8" }
+          - { cabal: "3.14", os: windows-latest, ghc: "9.6.6" }
+          - { cabal: "3.14", os: windows-latest, ghc: "9.8.4" }
+          - { cabal: "3.14", os: windows-latest, ghc: "9.10.1" }
+          # - { cabal: "3.14", os: windows-latest, ghc: "9.12.1" }
+          - { cabal: "3.14", os: macOS-13, ghc: "9.0.2" }
+          - { cabal: "3.14", os: macOS-latest, ghc: "9.2.8" }
+          - { cabal: "3.14", os: macOS-latest, ghc: "9.4.8" }
+          - { cabal: "3.14", os: macOS-latest, ghc: "9.6.6" }
+          - { cabal: "3.14", os: macOS-latest, ghc: "9.8.4" }
+          - { cabal: "3.14", os: macOS-latest, ghc: "9.10.1" }
+          # - { cabal: "3.14", os: macOS-latest, ghc: "9.12.1" }
 
     env:
       cache-version: v0 # bump up this version to invalidate currently stored cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.1.1.0
 
+* Add `MemPack` instance for `Void`
 * Add `packWithByteArray` and `packWithMutableByteArray`
 * Fix infinite loop during list decoding when length encoded was negative
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.1.1.0
 
+* Add helpers `packByteStringM`, `unpackByteStringM` and `unpackByteArrayLen`
 * Add `MemPack` instance for lazy `ByteString`
 * Add `MemPack` instance for `Text`
 * Add `MemPack` instance for `Void`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.1.1.0
 
+* Add `MemPack` instance for lazy `ByteString`
 * Add `MemPack` instance for `Text`
 * Add `MemPack` instance for `Void`
 * Add `packWithByteArray` and `packWithMutableByteArray`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.1.1.0
 
+* Add `MemPack` instance for `Text`
 * Add `MemPack` instance for `Void`
 * Add `packWithByteArray` and `packWithMutableByteArray`
 * Fix infinite loop during list decoding when length encoded was negative

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,9 @@
+packages:
+  .
+
+-- remove once `serialise` is compatible with ghc-9.12
+allow-newer:
+  serialise:base
+
+-- Always build tests
+tests: True

--- a/mempack.cabal
+++ b/mempack.cabal
@@ -20,8 +20,9 @@ tested-with:         GHC == 8.6.5
                    , GHC == 9.2.8
                    , GHC == 9.4.8
                    , GHC == 9.6.6
-                   , GHC == 9.8.2
+                   , GHC == 9.8.4
                    , GHC == 9.10.1
+                   , GHC == 9.12.1
 
 library
   hs-source-dirs:      src

--- a/mempack.cabal
+++ b/mempack.cabal
@@ -60,6 +60,7 @@ test-suite tests
                     , mtl
                     , QuickCheck
                     , random >=1.2.1
+                    , text
   if !impl(ghc >= 9.4)
     build-depends:     data-array-byte
 

--- a/src/Data/MemPack.hs
+++ b/src/Data/MemPack.hs
@@ -741,25 +741,25 @@ instance (MemPack a, MemPack b) => MemPack (a, b) where
   packedByteCount (a, b) = packedByteCount a + packedByteCount b
   {-# INLINE packedByteCount #-}
   packM (a, b) = packM a >> packM b
-  {-# INLINE packM #-}
+  {-# INLINEABLE packM #-}
   unpackM = do
     !a <- unpackM
     !b <- unpackM
     pure (a, b)
-  {-# INLINE unpackM #-}
+  {-# INLINEABLE unpackM #-}
 
 instance (MemPack a, MemPack b, MemPack c) => MemPack (a, b, c) where
   typeName = "(" ++ typeName @a ++ "," ++ typeName @b ++ "," ++ typeName @c ++ ")"
   packedByteCount (a, b, c) = packedByteCount a + packedByteCount b + packedByteCount c
   {-# INLINE packedByteCount #-}
   packM (a, b, c) = packM a >> packM b >> packM c
-  {-# INLINE packM #-}
+  {-# INLINEABLE packM #-}
   unpackM = do
     !a <- unpackM
     !b <- unpackM
     !c <- unpackM
     pure (a, b, c)
-  {-# INLINE unpackM #-}
+  {-# INLINEABLE unpackM #-}
 
 instance (MemPack a, MemPack b, MemPack c, MemPack d) => MemPack (a, b, c, d) where
   typeName = "(" ++ typeName @a ++ "," ++ typeName @b ++ "," ++ typeName @c ++ "," ++ typeName @d ++ ")"
@@ -767,14 +767,14 @@ instance (MemPack a, MemPack b, MemPack c, MemPack d) => MemPack (a, b, c, d) wh
   {-# INLINE packedByteCount #-}
   packM (a, b, c, d) =
     packM a >> packM b >> packM c >> packM d
-  {-# INLINE packM #-}
+  {-# INLINEABLE packM #-}
   unpackM = do
     !a <- unpackM
     !b <- unpackM
     !c <- unpackM
     !d <- unpackM
     pure (a, b, c, d)
-  {-# INLINE unpackM #-}
+  {-# INLINEABLE unpackM #-}
 
 instance (MemPack a, MemPack b, MemPack c, MemPack d, MemPack e) => MemPack (a, b, c, d, e) where
   typeName =
@@ -793,7 +793,7 @@ instance (MemPack a, MemPack b, MemPack c, MemPack d, MemPack e) => MemPack (a, 
   {-# INLINE packedByteCount #-}
   packM (a, b, c, d, e) =
     packM a >> packM b >> packM c >> packM d >> packM e
-  {-# INLINE packM #-}
+  {-# INLINEABLE packM #-}
   unpackM = do
     !a <- unpackM
     !b <- unpackM
@@ -801,7 +801,7 @@ instance (MemPack a, MemPack b, MemPack c, MemPack d, MemPack e) => MemPack (a, 
     !d <- unpackM
     !e <- unpackM
     pure (a, b, c, d, e)
-  {-# INLINE unpackM #-}
+  {-# INLINEABLE unpackM #-}
 
 instance (MemPack a, MemPack b, MemPack c, MemPack d, MemPack e, MemPack f) => MemPack (a, b, c, d, e, f) where
   typeName =
@@ -826,7 +826,7 @@ instance (MemPack a, MemPack b, MemPack c, MemPack d, MemPack e, MemPack f) => M
   {-# INLINE packedByteCount #-}
   packM (a, b, c, d, e, f) =
     packM a >> packM b >> packM c >> packM d >> packM e >> packM f
-  {-# INLINE packM #-}
+  {-# INLINEABLE packM #-}
   unpackM = do
     !a <- unpackM
     !b <- unpackM
@@ -835,7 +835,7 @@ instance (MemPack a, MemPack b, MemPack c, MemPack d, MemPack e, MemPack f) => M
     !e <- unpackM
     !f <- unpackM
     pure (a, b, c, d, e, f)
-  {-# INLINE unpackM #-}
+  {-# INLINEABLE unpackM #-}
 
 instance
   (MemPack a, MemPack b, MemPack c, MemPack d, MemPack e, MemPack f, MemPack g) =>
@@ -865,7 +865,7 @@ instance
   {-# INLINE packedByteCount #-}
   packM (a, b, c, d, e, f, g) =
     packM a >> packM b >> packM c >> packM d >> packM e >> packM f >> packM g
-  {-# INLINE packM #-}
+  {-# INLINEABLE packM #-}
   unpackM = do
     !a <- unpackM
     !b <- unpackM
@@ -875,7 +875,7 @@ instance
     !f <- unpackM
     !g <- unpackM
     pure (a, b, c, d, e, f, g)
-  {-# INLINE unpackM #-}
+  {-# INLINEABLE unpackM #-}
 
 instance MemPack a => MemPack [a] where
   typeName = "[" ++ typeName @a ++ "]"
@@ -1033,24 +1033,25 @@ packIncrement a =
 guardAdvanceUnpack :: Buffer b => Int -> Unpack b Int
 guardAdvanceUnpack n@(I# n#) = do
   buf <- ask
-  let len = bufferByteCount buf
-      failOutOfBytes i =
-        failUnpack $
-          toSomeError $
-            RanOutOfBytesError
-              { ranOutOfBytesRead = i
-              , ranOutOfBytesAvailable = len
-              , ranOutOfBytesRequested = n
-              }
+  let !len = bufferByteCount buf
   -- Check that we still have enough bytes, while guarding against integer overflow.
   join $ state $ \i@(I# i#) ->
     case addIntC# i# n# of
-      (# adv#, 0# #) ->
-        if len < I# adv#
-          then (failOutOfBytes i, i)
-          else (pure i, I# adv#)
-      _ -> (failOutOfBytes i, i)
+      (# adv#, 0# #)
+        | len >= I# adv# -> (pure i, I# adv#)
+      _ -> (failOutOfBytes i len n, i)
 {-# INLINE guardAdvanceUnpack #-}
+
+failOutOfBytes :: Int -> Int -> Int -> Unpack b a
+failOutOfBytes i len n =
+  failUnpack $
+    toSomeError $
+      RanOutOfBytesError
+        { ranOutOfBytesRead = i
+        , ranOutOfBytesAvailable = len
+        , ranOutOfBytesRequested = n
+        }
+{-# NOINLINE failOutOfBytes #-}
 
 -- | Serialize a type into an unpinned `ByteArray`
 --
@@ -1130,21 +1131,25 @@ packWithMutableByteArray ::
 packWithMutableByteArray isPinned name len packerM = do
   mba <- newMutableByteArray isPinned len
   filledBytes <- execStateT (runPack packerM mba) 0
-  when (filledBytes /= len) $
-    if (filledBytes < len)
-      then
-        error $
-          "Some bug in 'packM' was detected. Buffer of length " <> showBytes len
-            ++ " was not fully filled while packing " <> name
-            ++ ". Unfilled " <> showBytes (len - filledBytes) <> "."
-      else
-        -- This is a critical error, therefore we are not gracefully failing this unpacking
-        error $
-          "Potential buffer overflow. Some bug in 'packM' was detected while packing " <> name
-            ++ ". Filled " <> showBytes (filledBytes - len) <> " more than allowed into a buffer of length "
-            ++ show len
+  when (filledBytes /= len) $ errorFilledBytes name filledBytes len
   pure mba
-{-# INLINE packWithMutableByteArray #-}
+{-# INLINEABLE packWithMutableByteArray #-}
+
+-- | This is a critical error, therefore we are not gracefully failing this unpacking
+errorFilledBytes :: HasCallStack => [Char] -> Int -> Int -> a
+errorFilledBytes name filledBytes len =
+  if filledBytes < len
+    then
+      error $
+        "Some bug in 'packM' was detected. Buffer of length " <> showBytes len
+          ++ " was not fully filled while packing " <> name
+          ++ ". Unfilled " <> showBytes (len - filledBytes) <> "."
+    else
+      error $
+        "Potential buffer overflow. Some bug in 'packM' was detected while packing " <> name
+          ++ ". Filled " <> showBytes (filledBytes - len) <> " more than allowed into a buffer of length "
+          ++ show len
+{-# NOINLINE errorFilledBytes #-}
 
 -- | Helper function for packing a `ByteString` without its length being packed first.
 --
@@ -1166,6 +1171,7 @@ unpackByteStringM ::
   Int ->
   Unpack b ByteString
 unpackByteStringM len = pinnedByteArrayToByteString <$> unpackByteArrayLen True len
+{-# INLINE unpackByteStringM #-}
 
 -- | Unpack a memory `Buffer` into a type using its `MemPack` instance. Besides the
 -- unpacked type it also returns an index into a buffer where unpacked has stopped.
@@ -1173,14 +1179,18 @@ unpackLeftOver :: forall a b. (MemPack a, Buffer b, HasCallStack) => b -> Fail S
 unpackLeftOver b = do
   let len = bufferByteCount b
   res@(_, consumedBytes) <- runStateT (runUnpack unpackM b) 0
-  when (consumedBytes > len) $
-    -- This is a critical error, therefore we are not gracefully failing this unpacking
-    error $
-      "Potential buffer overflow. Some bug in 'unpackM' was detected while unpacking " <> typeName @a
-        ++ ". Consumed " <> showBytes (consumedBytes - len) <> " more than allowed from a buffer of length "
-        ++ show len
+  when (consumedBytes > len) $ errorLeftOver (typeName @a) consumedBytes len
   pure res
 {-# INLINEABLE unpackLeftOver #-}
+
+-- | This is a critical error, therefore we are not gracefully failing this unpacking
+errorLeftOver :: HasCallStack => String -> Int -> Int -> a
+errorLeftOver name consumedBytes len =
+  error $
+    "Potential buffer overflow. Some bug in 'unpackM' was detected while unpacking " <> name
+      ++ ". Consumed " <> showBytes (consumedBytes - len) <> " more than allowed from a buffer of length "
+      ++ show len
+{-# NOINLINE errorLeftOver #-}
 
 -- | Unpack a memory `Buffer` into a type using its `MemPack` instance. Besides potential
 -- unpacking failures due to a malformed buffer it will also fail the supplied `Buffer`
@@ -1188,33 +1198,37 @@ unpackLeftOver b = do
 -- possible.
 unpack :: forall a b. (MemPack a, Buffer b, HasCallStack) => b -> Either SomeError a
 unpack = first fromMultipleErrors . runFailAgg . unpackFail
-{-# INLINE unpack #-}
+{-# INLINEABLE unpack #-}
 
 -- | Same as `unpack` except fails in a `Fail` monad, instead of `Either`.
 unpackFail :: forall a b. (MemPack a, Buffer b, HasCallStack) => b -> Fail SomeError a
 unpackFail b = do
   let len = bufferByteCount b
   (a, consumedBytes) <- unpackLeftOver b
-  when (consumedBytes /= len) $
-    failT $
-      toSomeError $
-        NotFullyConsumedError
-          { notFullyConsumedRead = consumedBytes
-          , notFullyConsumedAvailable = len
-          , notFullyConsumedTypeName = typeName @a
-          }
+  when (consumedBytes /= len) $ unpackFailNotFullyConsumed (typeName @a) consumedBytes len
   pure a
 {-# INLINEABLE unpackFail #-}
+
+unpackFailNotFullyConsumed :: Applicative m => String -> Int -> Int -> FailT SomeError m a
+unpackFailNotFullyConsumed name consumedBytes len =
+  failT $
+    toSomeError $
+      NotFullyConsumedError
+        { notFullyConsumedRead = consumedBytes
+        , notFullyConsumedAvailable = len
+        , notFullyConsumedTypeName = name
+        }
+{-# NOINLINE unpackFailNotFullyConsumed #-}
 
 -- | Same as `unpackFail` except fails in any `MonadFail`, instead of `Fail`.
 unpackMonadFail :: forall a b m. (MemPack a, Buffer b, F.MonadFail m) => b -> m a
 unpackMonadFail = either (F.fail . show) pure . unpack
-{-# INLINE unpackMonadFail #-}
+{-# INLINEABLE unpackMonadFail #-}
 
 -- | Same as `unpack` except throws a runtime exception upon a failure
 unpackError :: forall a b. (MemPack a, Buffer b, HasCallStack) => b -> a
 unpackError = errorFail . unpackFail
-{-# INLINE unpackError #-}
+{-# INLINEABLE unpackError #-}
 
 -- | Variable length encoding for bounded types. This type of encoding will use less
 -- memory for small values, but for larger values it will consume more memory and will be
@@ -1308,9 +1322,10 @@ packedVarLenByteCount (VarLen x) =
     (q, _) -> q + 1
 {-# INLINE packedVarLenByteCount #-}
 
-errorTooManyBits :: [Char] -> a
+errorTooManyBits :: HasCallStack => String -> a
 errorTooManyBits name =
   error $ "Bug detected. Trying to pack more bits for " ++ name ++ " than it should be posssible"
+{-# NOINLINE errorTooManyBits #-}
 
 packIntoCont7 ::
   (Bits t, Integral t) => t -> (Int -> Pack s ()) -> Int -> Pack s ()
@@ -1321,7 +1336,7 @@ packIntoCont7 x cont n
       cont (n - 7)
   where
     topBit8 :: Word8
-    topBit8 = 0b_1000_0000
+    !topBit8 = 0b_1000_0000
 {-# INLINE packIntoCont7 #-}
 
 -- | Decode a variable length integral value that is encoded with 7 bits of data
@@ -1357,13 +1372,17 @@ unpack7BitVarLenLast mask firstByte acc = do
   res <- unpack7BitVarLen (\_ _ -> F.fail "Too many bytes.") firstByte acc
   -- Only while decoding the last 7bits we check if there was too many
   -- bits supplied at the beginning.
-  unless (firstByte .&. mask == 0b_1000_0000) $
-    F.fail $
-      "Unexpected bits for "
-        ++ typeName @t
-        ++ " were set in the first byte of 'VarLen': 0x" <> showHex firstByte ""
+  unless (firstByte .&. mask == 0b_1000_0000) $ unpack7BitVarLenLastFail (typeName @t) firstByte
   pure res
 {-# INLINE unpack7BitVarLenLast #-}
+
+unpack7BitVarLenLastFail :: F.MonadFail m => String -> Word8 -> m a
+unpack7BitVarLenLastFail name firstByte =
+  F.fail $
+    "Unexpected bits for "
+      ++ name
+      ++ " were set in the first byte of 'VarLen': 0x" <> showHex firstByte ""
+{-# NOINLINE unpack7BitVarLenLastFail #-}
 
 -- | This is a helper type useful for serializing number of elements in data
 -- structures. It uses `VarLen` underneath, since sizes of common data structures aren't
@@ -1384,16 +1403,23 @@ instance Enum Length where
 instance MemPack Length where
   packedByteCount = packedByteCount . VarLen . fromIntegral @Int @Word . unLength
   packM (Length n)
-    | n < 0 = error $ "Length cannot be negative. Supplied: " ++ show n
+    | n < 0 = packLengthError n
     | otherwise = packM (VarLen (fromIntegral @Int @Word n))
   {-# INLINE packM #-}
   unpackM = do
     VarLen (w :: Word) <- unpackM
-    when (testBit w (finiteBitSize w - 1)) $
-      F.fail $
-        "Attempt to unpack negative length was detected: " ++ show (fromIntegral @Word @Int w)
+    when (testBit w (finiteBitSize w - 1)) $ upackLengthFail w
     pure $ Length $ fromIntegral @Word @Int w
   {-# INLINE unpackM #-}
+
+packLengthError :: Int -> a
+packLengthError n = error $ "Length cannot be negative. Supplied: " ++ show n
+{-# NOINLINE packLengthError #-}
+
+upackLengthFail :: F.MonadFail m => Word -> m a
+upackLengthFail w =
+  F.fail $ "Attempt to unpack negative length was detected: " ++ show (fromIntegral @Word @Int w)
+{-# NOINLINE upackLengthFail #-}
 
 -- | This is a helper type that is useful for creating `MemPack` instances for sum types.
 newtype Tag = Tag {unTag :: Word8}

--- a/src/Data/MemPack.hs
+++ b/src/Data/MemPack.hs
@@ -51,6 +51,9 @@ module Data.MemPack (
   -- ** Helpers
   failUnpack,
   unpackByteArray,
+  unpackByteArrayLen,
+  packByteStringM,
+  unpackByteStringM,
 
   -- * Helper packers
   VarLen (..),
@@ -992,11 +995,16 @@ instance MemPack Text where
   {-# INLINE unpackM #-}
 {- FOURMOLU_ENABLE -}
 
--- | This is the implementation of `unpackM` for `ByteArray` and `ByteString`
+-- | This is the implementation of `unpackM` for `ByteArray`, `ByteString` and `ShortByteString`
 unpackByteArray :: Buffer b => Bool -> Unpack b ByteArray
 unpackByteArray isPinned = unpackByteArrayLen isPinned . unLength =<< unpackM
 {-# INLINE unpackByteArray #-}
 
+-- | Unpack a `ByteArray` with supplied number of bytes.
+--
+-- Similar to `unpackByteArray`, except it does not unpack a length.
+--
+-- @since 0.1.1
 unpackByteArrayLen :: Buffer b => Bool -> Int -> Unpack b ByteArray
 unpackByteArrayLen isPinned len@(I# len#) = do
   I# curPos# <- guardAdvanceUnpack len
@@ -1139,6 +1147,8 @@ packWithMutableByteArray isPinned name len packerM = do
 {-# INLINE packWithMutableByteArray #-}
 
 -- | Helper function for packing a `ByteString` without its length being packed first.
+--
+-- @since 0.1.1
 packByteStringM :: ByteString -> Pack s ()
 packByteStringM bs = do
   let !len@(I# len#) = bufferByteCount bs
@@ -1148,6 +1158,8 @@ packByteStringM bs = do
 {-# INLINE packByteStringM #-}
 
 -- | Unpack a `ByteString` of a specified size.
+--
+-- @since 0.1.1
 unpackByteStringM ::
   Buffer b =>
   -- | number of bytes to unpack

--- a/src/Data/MemPack.hs
+++ b/src/Data/MemPack.hs
@@ -250,7 +250,7 @@ class MemPack a where
 instance MemPack () where
   packedByteCount _ = 0
   {-# INLINE packedByteCount #-}
-  packM _ = pure ()
+  packM () = pure ()
   {-# INLINE packM #-}
   unpackM = pure ()
   {-# INLINE unpackM #-}

--- a/src/Data/MemPack.hs
+++ b/src/Data/MemPack.hs
@@ -92,6 +92,7 @@ import Data.MemPack.Error
 import Data.Ratio
 import Data.Semigroup (Sum (..))
 import Data.Typeable
+import Data.Void (Void, absurd)
 import GHC.Exts
 import GHC.Int
 import GHC.ST (ST (..), runST)
@@ -243,6 +244,11 @@ instance MemPack () where
   {-# INLINE packM #-}
   unpackM = pure ()
   {-# INLINE unpackM #-}
+
+instance MemPack Void where
+  packedByteCount _ = 0
+  packM = absurd
+  unpackM = F.fail "Void is unpackable"
 
 instance MemPack Bool where
   packedByteCount _ = packedTagByteCount

--- a/src/Data/MemPack/Error.hs
+++ b/src/Data/MemPack/Error.hs
@@ -27,7 +27,7 @@ instance Show SomeError where
 
 instance Exception SomeError
 
--- | Very similar interface to `Exceptions`, except not intended for run time exceptions.
+-- | Very similar interface to `Exceptions`, except not intended for runtime exceptions.
 class Show e => Error e where
   toSomeError :: e -> SomeError
   default toSomeError :: Typeable e => e -> SomeError
@@ -65,6 +65,8 @@ fromMultipleErrors es =
     [] -> toSomeError UnknownError
     [e] -> e
     e : rest -> toSomeError $ ManyErrors (e :| rest)
+{-# NOINLINE fromMultipleErrors #-}
+
 
 data RanOutOfBytesError = RanOutOfBytesError
   { ranOutOfBytesRead :: Int

--- a/tests/Test/Common.hs
+++ b/tests/Test/Common.hs
@@ -10,6 +10,7 @@ import Data.Array.Byte (ByteArray (..))
 import Data.ByteString (ByteString)
 import Data.ByteString.Short.Internal as SBS (ShortByteString (..))
 import Data.MemPack.Buffer (byteArrayFromShortByteString)
+import qualified Data.Text as T
 import System.Random.Stateful
 import Test.Hspec as X
 import Test.Hspec.QuickCheck as X
@@ -35,6 +36,9 @@ instance Arbitrary ByteString where
 
 instance Arbitrary SBS.ShortByteString where
   arbitrary = qcShortByteString . getNonNegative =<< arbitrary
+
+instance Arbitrary T.Text where
+  arbitrary = T.pack <$> arbitrary
 
 qcByteArray :: Int -> Gen ByteArray
 qcByteArray n = byteArrayFromShortByteString <$> qcShortByteString n

--- a/tests/Test/Common.hs
+++ b/tests/Test/Common.hs
@@ -9,6 +9,7 @@ module Test.Common (
 import Data.Array.Byte (ByteArray (..))
 import Data.ByteString (ByteString)
 import Data.ByteString.Short.Internal as SBS (ShortByteString (..))
+import qualified Data.ByteString.Lazy as BSL
 import Data.MemPack.Buffer (byteArrayFromShortByteString)
 import qualified Data.Text as T
 import System.Random.Stateful
@@ -36,6 +37,9 @@ instance Arbitrary ByteString where
 
 instance Arbitrary SBS.ShortByteString where
   arbitrary = qcShortByteString . getNonNegative =<< arbitrary
+
+instance Arbitrary BSL.ByteString where
+  arbitrary = BSL.fromChunks <$> arbitrary
 
 instance Arbitrary T.Text where
   arbitrary = T.pack <$> arbitrary

--- a/tests/Test/MemPackSpec.hs
+++ b/tests/Test/MemPackSpec.hs
@@ -27,6 +27,7 @@ import Data.MemPack
 import Data.MemPack.Buffer
 import Data.MemPack.Error
 import Data.Ratio
+import Data.Text (Text)
 import Data.Word
 import Foreign.Ptr (IntPtr (..), Ptr, intPtrToPtr)
 import Foreign.StablePtr (StablePtr, castPtrToStablePtr, castStablePtrToPtr)
@@ -216,8 +217,8 @@ spec = do
   memPackSpec @[E Word]
   memPackSpec @(E Int, E Word)
   memPackSpec @(E Int8, E Word8, E Char)
-  memPackSpec @(E Int16, E Word16, Float, Double)
-  memPackSpec @(E Int32, E Word32, Float, Double, Ptr Char)
+  memPackSpec @(E Int16, E Word16, ByteArray, Double)
+  memPackSpec @(E Int32, E Word32, Float, ByteString, Ptr Char)
   memPackSpec @(E Int64, E Word64, Length, VarLen Word, StablePtr Char, [VarLen Word32])
   memPackSpec @(Tag, Int, Int8, Int16, Int32, Int64, Backtrack)
   memPackSpec @(E (VarLen Word))
@@ -234,7 +235,8 @@ spec = do
   memPackSpec @(Ratio (E Int))
   memPackSpec @ByteArray
   memPackSpec @ByteString
-  memPackSpec @ShortByteString
+  memPackSpec @ByteArray
+  memPackSpec @Text
   memPackSpec @Backtrack
   prop "Out of bound char" $ forAll (choose (0x110000, maxBound :: Word32)) $ \w32 ->
     unpack @Char (pack w32) `shouldSatisfy` isLeft

--- a/tests/Test/MemPackSpec.hs
+++ b/tests/Test/MemPackSpec.hs
@@ -19,6 +19,7 @@ import Data.Array.Byte (ByteArray)
 import Data.Bits
 import Data.ByteString (ByteString)
 import Data.ByteString.Short (ShortByteString)
+import qualified Data.ByteString.Lazy as BSL
 import Data.Complex
 import Data.Either (isLeft)
 import Data.Function (fix)
@@ -235,6 +236,7 @@ spec = do
   memPackSpec @(Ratio (E Int))
   memPackSpec @ByteArray
   memPackSpec @ByteString
+  memPackSpec @BSL.ByteString
   memPackSpec @ByteArray
   memPackSpec @Text
   memPackSpec @Backtrack


### PR DESCRIPTION
Adding an instance for `Text`, `Void` and lazy `ByteString` types

`Text` instance results in conversion to utf8 twice for `text < 2.x`. In order to fix it some sort of adjustment to the `MemPack` interface will be necessary